### PR TITLE
chore: bump events-presenter chart version to 0.6.6 in ingress, loadb…

### DIFF
--- a/krateo.ingress.yaml
+++ b/krateo.ingress.yaml
@@ -309,7 +309,7 @@ steps:
       releaseName: events-presenter
       repo: events-presenter
       url: https://charts.krateo.io
-      version: 0.6.4
+      version: 0.6.6
       values:
         service:
           type: NodePort

--- a/krateo.loadbalancer.yaml
+++ b/krateo.loadbalancer.yaml
@@ -336,7 +336,7 @@ steps:
       releaseName: events-presenter
       repo: events-presenter
       url: https://charts.krateo.io
-      version: 0.6.4
+      version: 0.6.6
       values:
         service:
           type: LoadBalancer

--- a/krateo.nodeport.yaml
+++ b/krateo.nodeport.yaml
@@ -305,7 +305,7 @@ steps:
       releaseName: events-presenter
       repo: events-presenter
       url: https://charts.krateo.io
-      version: 0.6.4
+      version: 0.6.6
       values:
         service:
           type: NodePort


### PR DESCRIPTION
…alancer, and nodeport configurations