### PR TITLE
fix: moved cratedb system user scret name to root values for db-handler

### DIFF
--- a/krateo.ingress.yaml
+++ b/krateo.ingress.yaml
@@ -500,9 +500,9 @@ steps:
               paths:
                 - path: /
                   pathType: Prefix
+        cratedbUserSystemName: cratedb-system-credentials
         env:
           CRATE_HOST: cratedb.{{ .Namespace }}.svc.cluster.local
-          cratedbUserSystemName: cratedb-system-credentials
   
   # Extract finops database handler port
   - id: extract-finops-database-handler-port

--- a/krateo.loadbalancer.yaml
+++ b/krateo.loadbalancer.yaml
@@ -532,9 +532,9 @@ steps:
           pullPolicy: IfNotPresent
         service:
           type: LoadBalancer
+        cratedbUserSystemName: cratedb-system-credentials
         env:
           CRATE_HOST: cratedb.{{ .Namespace }}.svc.cluster.local
-          cratedbUserSystemName: cratedb-system-credentials
 
   # Extract finops database handler port
   - id: extract-finops-database-handler-port

--- a/krateo.nodeport.yaml
+++ b/krateo.nodeport.yaml
@@ -490,9 +490,9 @@ steps:
         service:
           type: NodePort
           nodePort: 30086
+        cratedbUserSystemName: cratedb-system-credentials
         env:
           CRATE_HOST: cratedb.{{ .Namespace }}.svc.cluster.local
-          cratedbUserSystemName: cratedb-system-credentials
 
   # Extract finops database handler port
   - id: extract-finops-database-handler-port


### PR DESCRIPTION
Change to match structure of [finops-database-handler-chart values](https://github.com/krateoplatformops/finops-database-handler-chart/blob/8938da11d20b780756283d80f177954df74b3429/chart/values.yaml#L6).