### PR TITLE
Add logs ingestion and presentation components to service profiles

### DIFF
--- a/gitops-examples/argocd/ingress/job.yaml
+++ b/gitops-examples/argocd/ingress/job.yaml
@@ -48,7 +48,7 @@ spec:
             - install
             - apply
             - --version
-            - "3.1.0-rc1-dev3"
+            - "3.1.0-rc1-dev4"
             - --repository
             - "https://github.com/krateoplatformops/releases"
             - --namespace

--- a/gitops-examples/argocd/loadbalancer/job.yaml
+++ b/gitops-examples/argocd/loadbalancer/job.yaml
@@ -48,7 +48,7 @@ spec:
             - install
             - apply
             - --version
-            - "3.1.0-rc1-dev3"
+            - "3.1.0-rc1-dev4"
             - --repository
             - "https://github.com/krateoplatformops/releases"
             - --namespace

--- a/gitops-examples/argocd/nodeport/job.yaml
+++ b/gitops-examples/argocd/nodeport/job.yaml
@@ -48,7 +48,7 @@ spec:
             - install
             - apply
             - --version
-            - "3.1.0-rc1-dev3"
+            - "3.1.0-rc1-dev4"
             - --repository
             - "https://github.com/krateoplatformops/releases"
             - --namespace

--- a/krateo.ingress.yaml
+++ b/krateo.ingress.yaml
@@ -37,7 +37,13 @@ componentsDefinition:
     steps:
       - install-events-ingester
       - install-events-presenter
-  
+
+  logs-stack:
+    description: "Pod log ingestion and query stack"
+    steps:
+      - install-logs-ingester
+      - install-logs-presenter
+
   frontend:
     description: "Web UI and platform dashboard (Ingress-exposed)"
     steps:
@@ -346,6 +352,71 @@ steps:
         dbSecret:
           name: krateo-db
 
+  # Logs ingester
+  - id: install-logs-ingester
+    type: chart
+    with:
+      releaseName: logs-ingester
+      repo: logs-ingester
+      url: https://charts.krateo.io
+      version: 0.2.0
+      values:
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-rw.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+
+          # Namespace to observe (defaults to the release namespace).
+          # The chart's namespace-scoped Role/RoleBinding (pods get/list/watch,
+          # pods/log get) are created in this namespace.
+          NAMESPACE: "{{ .Namespace }}"
+          # Label selector of the pods whose logs are ingested. REQUIRED:
+          # without it the ingester does not start.
+          SELECTOR: "app.kubernetes.io/part-of=krateo"
+
+        secret:
+          name: krateo-db
+
+  # Logs presenter
+  - id: install-logs-presenter
+    type: chart
+    with:
+      releaseName: logs-presenter
+      repo: logs-presenter
+      url: https://charts.krateo.io
+      version: 0.1.0
+      wait: true
+      timeout: 15m
+      values:
+        service:
+          type: NodePort
+          nodePort: 30085
+        ingress:
+          enabled: true
+          className: null
+          hosts:
+            - host: logs-presenter.krateoplatformops.io
+              paths:
+                - path: /
+                  pathType: Prefix
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-ro.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+          AUTHN_NS: "{{ .Namespace }}"
+
+        dbSecret:
+          name: krateo-db
+
+        jwtSignKeySecret:
+          name: jwt-sign-key
+
   # Frontend UI
   - id: install-frontend
     type: chart
@@ -393,7 +464,7 @@ steps:
       releaseName: core-provider
       repo: core-provider
       url: https://charts.krateo.io
-      version: 1.0.0
+      version: 1.0.1-rc1
       values:
         image:
           repository: ghcr.io/krateoplatformops/core-provider

--- a/krateo.loadbalancer.yaml
+++ b/krateo.loadbalancer.yaml
@@ -44,6 +44,12 @@ componentsDefinition:
       - extract-events-presenter-lb-ip
       - extract-events-presenter-lb-port
 
+  logs-stack:
+    description: "Pod log ingestion and query stack"
+    steps:
+      - install-logs-ingester
+      - install-logs-presenter
+
   frontend:
     description: "Web UI and platform dashboard (LoadBalancer-exposed)"
     steps:
@@ -392,6 +398,62 @@ steps:
           namespace: {{ .Namespace }}
         selector: .spec.ports[0].port
 
+  # Logs ingester
+  - id: install-logs-ingester
+    type: chart
+    with:
+      releaseName: logs-ingester
+      repo: logs-ingester
+      url: https://charts.krateo.io
+      version: 0.2.0
+      values:
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-rw.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+
+          # Namespace to observe (defaults to the release namespace).
+          # The chart's namespace-scoped Role/RoleBinding (pods get/list/watch,
+          # pods/log get) are created in this namespace.
+          NAMESPACE: "{{ .Namespace }}"
+          # Label selector of the pods whose logs are ingested. REQUIRED:
+          # without it the ingester does not start.
+          SELECTOR: "app.kubernetes.io/part-of=krateo"
+
+        secret:
+          name: krateo-db
+
+  # Logs presenter
+  - id: install-logs-presenter
+    type: chart
+    with:
+      releaseName: logs-presenter
+      repo: logs-presenter
+      url: https://charts.krateo.io
+      version: 0.1.0
+      wait: true
+      timeout: 15m
+      values:
+        service:
+          type: LoadBalancer
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-ro.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+          AUTHN_NS: "{{ .Namespace }}"
+
+        dbSecret:
+          name: krateo-db
+
+        jwtSignKeySecret:
+          name: jwt-sign-key
+
   # Frontend UI
   - id: install-frontend
     type: chart
@@ -433,7 +495,7 @@ steps:
       releaseName: core-provider
       repo: core-provider
       url: https://charts.krateo.io
-      version: 1.0.0
+      version: 1.0.1-rc1
       values:
         image:
           repository: ghcr.io/krateoplatformops/core-provider

--- a/krateo.nodeport.yaml
+++ b/krateo.nodeport.yaml
@@ -41,6 +41,12 @@ componentsDefinition:
       - install-events-presenter
       - extract-events-presenter-port
 
+  logs-stack:
+    description: "Pod log ingestion and query stack"
+    steps:
+      - install-logs-ingester
+      - install-logs-presenter
+
   frontend:
     description: "Web UI and platform dashboard"
     steps:
@@ -349,6 +355,63 @@ steps:
           namespace: {{ .Namespace }}
         selector: .spec.ports[0].nodePort
 
+  # Logs ingester
+  - id: install-logs-ingester
+    type: chart
+    with:
+      releaseName: logs-ingester
+      repo: logs-ingester
+      url: https://charts.krateo.io
+      version: 0.2.0
+      values:
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-rw.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+
+          # Namespace to observe (defaults to the release namespace).
+          # The chart's namespace-scoped Role/RoleBinding (pods get/list/watch,
+          # pods/log get) are created in this namespace.
+          NAMESPACE: "{{ .Namespace }}"
+          # Label selector of the pods whose logs are ingested. REQUIRED:
+          # without it the ingester does not start.
+          SELECTOR: "app.kubernetes.io/part-of=krateo"
+
+        secret:
+          name: krateo-db
+
+  # Logs presenter
+  - id: install-logs-presenter
+    type: chart
+    with:
+      releaseName: logs-presenter
+      repo: logs-presenter
+      url: https://charts.krateo.io
+      version: 0.1.0
+      wait: true
+      timeout: 15m
+      values:
+        service:
+          type: NodePort
+          nodePort: 30085
+        config:
+          DEBUG: "false"
+          PORT: "8083"
+
+          DB_HOST: pg-cluster-ro.{{ .Namespace }}.svc.cluster.local
+          DB_NAME: krateo-db
+          DB_READY_TIMEOUT: "5m"
+          AUTHN_NS: "{{ .Namespace }}"
+
+        dbSecret:
+          name: krateo-db
+
+        jwtSignKeySecret:
+          name: jwt-sign-key
+
   # Frontend UI
   - id: install-frontend
     type: chart
@@ -392,7 +455,7 @@ steps:
       releaseName: core-provider
       repo: core-provider
       url: https://charts.krateo.io
-      version: 1.0.0
+      version: 1.0.1-rc1
       values:
         image:
           repository: ghcr.io/krateoplatformops/core-provider


### PR DESCRIPTION
This pull request introduces a new "logs-stack" feature across all deployment configurations (Ingress, NodePort, and LoadBalancer), enabling pod log ingestion and querying. It does so by adding steps to install both a logs ingester and a logs presenter, with environment-specific configuration. Additionally, it updates the `core-provider` chart version in all manifests.

**Logs stack integration:**

* Added a new `logs-stack` component to `componentsDefinition` in `krateo.ingress.yaml`, `krateo.nodeport.yaml`, and `krateo.loadbalancer.yaml`, defining steps to install log ingestion and presentation services. [[1]](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5R41-R46) [[2]](diffhunk://#diff-92a367c0ae68e2a035034d05734a243ec2835faa17fb51d08c29b320a00663aaR44-R49) [[3]](diffhunk://#diff-a36b47b6334d3a47fea4139954c63b2d5940f8a02924bb2888ab051ca2bdf3fcR47-R52)

* Added `install-logs-ingester` and `install-logs-presenter` steps in all deployment YAMLs:
  - [`install-logs-ingester`](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5R355-R419): Deploys the logs ingester chart with configuration for database connectivity, namespace, and pod selector. [[1]](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5R355-R419) [[2]](diffhunk://#diff-92a367c0ae68e2a035034d05734a243ec2835faa17fb51d08c29b320a00663aaR358-R414) [[3]](diffhunk://#diff-a36b47b6334d3a47fea4139954c63b2d5940f8a02924bb2888ab051ca2bdf3fcR401-R456)
  - [`install-logs-presenter`](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5R355-R419): Deploys the logs presenter chart with configuration for service exposure (NodePort, LoadBalancer, or Ingress), database access, and authentication. [[1]](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5R355-R419) [[2]](diffhunk://#diff-92a367c0ae68e2a035034d05734a243ec2835faa17fb51d08c29b320a00663aaR358-R414) [[3]](diffhunk://#diff-a36b47b6334d3a47fea4139954c63b2d5940f8a02924bb2888ab051ca2bdf3fcR401-R456)

**Core provider update:**

* Updated the `core-provider` chart version from `1.0.0` to `1.0.1-rc1` in all deployment manifests to ensure the latest release candidate is used. [[1]](diffhunk://#diff-1b463ede49668573ec80bbf7b80051d8148a3e978bb8102747d1169465767dd5L396-R467) [[2]](diffhunk://#diff-92a367c0ae68e2a035034d05734a243ec2835faa17fb51d08c29b320a00663aaL395-R458) [[3]](diffhunk://#diff-a36b47b6334d3a47fea4139954c63b2d5940f8a02924bb2888ab051ca2bdf3fcL436-R498)…Balancer, and NodePort profiles